### PR TITLE
Add name only when set channel is not empty

### DIFF
--- a/Name2Chat.lua
+++ b/Name2Chat.lua
@@ -75,7 +75,7 @@ local Options = {
 			desc = L["hideOnMatchingCharName_desc"],
 		},
 		ignoreExclamationMark = {
-			order = 9,
+			order = 10,
 			type = "toggle",
 			name = L["ignoreExclamationMark"],
 			desc = L["ignoreExclamationMark_desc"],
@@ -186,11 +186,12 @@ function Name2Chat:SendChatMessage(msg, chatType, language, channel)
 						msg = "(" .. self.db.profile.name .."): " .. msg
 					end
 
-				elseif self.db.profile.channel and chatType == "CHANNEL" then
-					--local id, chname = GetChannelName(channel)
-					--if strupper(self.db.profile.channel) == strupper(chname) then
+				elseif (self.db.profile.channel ~= "") and chatType == "CHANNEL" then
+
+					local id, chname = GetChannelName(channel)
+					if strupper(self.db.profile.channel) == strupper(chname) then
 						msg = "(" .. self.db.profile.name .."): " .. msg
-					--end
+					end
 				end
 
 			end


### PR DESCRIPTION
I had a problem of my name being added to General and Trade channels all the time, which made it uncomfortable to use the addon. I got it fixed with this change.

Simply asking if "self.db.profile.channel" seemed to always evaluate to true, so I changed it to not empty check.
I also uncommented the channel name comparisons to add name only to wanted channel and not every channel.

Not sure if there was two order 9s on purpose for Options args, but I set last option order to 10 instead of duplicate 9.